### PR TITLE
Switched token over to an environment variable.

### DIFF
--- a/app.js
+++ b/app.js
@@ -74,7 +74,7 @@ client.on("message", (message) => {
 });
 
 // Log the client in to establish a connection to Discord.
-client.login(config.discord_token).then(() => {
+client.login(process.env.DISCORD_TOKEN).then(() => {
 	console.log(`Successfully connected to Discord as '${client.user.username}'.`);
 }).catch(console.error);
 


### PR DESCRIPTION
Changed the Discord token to be loaded from an environment variable rather than the config, this will allow us to work with how Heroku handles their config variables.