### PR TITLE
Switch CI name to lint from build.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: CI
 on: [pull_request]
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,15 +1,11 @@
 name: CI
-
 on: [pull_request]
-
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
-    
     steps:
     - uses: actions/checkout@v1
     - name: Runs ESLint
       run: |
-        npm i 
+        npm i
         npm run lint


### PR DESCRIPTION
For some reason when I set up the action I called it `build` even though it runs ESLint, this pull request changes that so it is more clear in future pull requests.