### PR TITLE
Edited message update event handler so links don't get sent to logs

### DIFF
--- a/app.js
+++ b/app.js
@@ -66,9 +66,6 @@ client.on("message", (message) => {
 
 // Events
 client.on(MESSAGE_UPDATE, (oldMessage, newMessage) => {
-	if (oldMessage.content == newMessage.content) {
-		return;
-	}
 	events.getEvent(MESSAGE_UPDATE).run(oldMessage, newMessage);
 });
 

--- a/app.js
+++ b/app.js
@@ -44,7 +44,7 @@ sql.authenticate().then(() => {
 client.on("ready", () => {
 	AppLoader.setClient(client);
 	AppLoader.setConfig(config);
-	AppLoader.loadResources({commands, events});
+	AppLoader.loadResources({ commands, events });
 });
 
 // Run when a message is sent
@@ -66,6 +66,9 @@ client.on("message", (message) => {
 
 // Events
 client.on(MESSAGE_UPDATE, (oldMessage, newMessage) => {
+	if (oldMessage.content == newMessage.content) {
+		return;
+	}
 	events.getEvent(MESSAGE_UPDATE).run(oldMessage, newMessage);
 });
 

--- a/events/messageUpdate.js
+++ b/events/messageUpdate.js
@@ -6,21 +6,20 @@ const Discord = app.Discord;
 
 // The code that runs when the event is executed.
 function run(oldMessage, newMessage) {
-	if (oldMessage.content == newMessage.content) {
-		return;
-	}
-	if (![oldMessage.content, newMessage.content].includes("")) {
-		const logsChannel = oldMessage.guild.channels.find((channel) => {
-			return channel.id == config.logs_channel;
-		});
-		const embed = new Discord.RichEmbed();
+	if (oldMessage.content != newMessage.content) {
+		if (![oldMessage.content, newMessage.content].includes("")) {
+			const logsChannel = oldMessage.guild.channels.find((channel) => {
+				return channel.id == config.logs_channel;
+			});
+			const embed = new Discord.RichEmbed();
 
-		embed.setTitle("Message Updated");
-		embed.setDescription(`Author: ${oldMessage.author}\nChannel: ${oldMessage.channel}`);
-		embed.addField("Old Message", oldMessage.content || ".");
-		embed.addField("New Message", newMessage.content || ".");
+			embed.setTitle("Message Updated");
+			embed.setDescription(`Author: ${oldMessage.author}\nChannel: ${oldMessage.channel}`);
+			embed.addField("Old Message", oldMessage.content || ".");
+			embed.addField("New Message", newMessage.content || ".");
 
-		logsChannel.send({ embed });
+			logsChannel.send({ embed });
+		}
 	}
 }
 

--- a/events/messageUpdate.js
+++ b/events/messageUpdate.js
@@ -6,6 +6,9 @@ const Discord = app.Discord;
 
 // The code that runs when the event is executed.
 function run(oldMessage, newMessage) {
+	if (oldMessage.content == newMessage.content) {
+		return;
+	}
 	if (![oldMessage.content, newMessage.content].includes("")) {
 		const logsChannel = oldMessage.guild.channels.find((channel) => {
 			return channel.id == config.logs_channel;
@@ -17,7 +20,7 @@ function run(oldMessage, newMessage) {
 		embed.addField("Old Message", oldMessage.content || ".");
 		embed.addField("New Message", newMessage.content || ".");
 
-		logsChannel.send({embed});
+		logsChannel.send({ embed });
 	}
 }
 


### PR DESCRIPTION
### What does this change/add/remove?
Added condition to see if the old message was the same as the new message in the message update event.


### Why is this beneficial to the project?
Now links will not be sent to #logs whenever the metadata for the page is received and Discord adds an embed to the message.