### PR TITLE
Remove recieved message after execution if its a command message

### DIFF
--- a/app.js
+++ b/app.js
@@ -65,6 +65,7 @@ client.on("message", (message) => {
 			} else {
 				command.run(message);
 			}
+			message.delete(0);
 		}
 	}
 });


### PR DESCRIPTION
- command messages will be removed after execution

- cleans up the chat by just displaying the result of the command instead of the actual message such as `?rule 1` 
